### PR TITLE
Fix unspecified dependency on cl-macs.

### DIFF
--- a/trinary.el
+++ b/trinary.el
@@ -29,6 +29,8 @@
 
 ;;; Code:
 
+(require 'cl-macs)
+
 (defconst trinary--true 1)
 (defconst trinary--maybe 0)
 (defconst trinary--false -1)


### PR DESCRIPTION
Modulo a previous (require 'cl-macs), the following warning results
from (require 'trinary):

> Error (use-package): trinary/:catch: Symbol’s function definition is void: :print-function